### PR TITLE
Make the keymap selectors more specific.

### DIFF
--- a/keymaps/atom-hydra.json
+++ b/keymaps/atom-hydra.json
@@ -1,6 +1,8 @@
 {
   "atom-workspace atom-text-editor[data-grammar~='js']": {
-    "ctrl-alt-o": "atom-hydra:toggle",
+    "ctrl-alt-o": "atom-hydra:toggle"
+  },
+  ".hydra-enabled atom-workspace atom-text-editor[data-grammar~='js']": {
     "shift-enter": "atom-hydra:evalLine",
     "ctrl-enter": "atom-hydra:evalBlock",
     "ctrl-alt-enter": "atom-hydra:evalBlock"


### PR DESCRIPTION
Hey, not sure what your feeling about PRs is. This change made the Atom package more useful for me, hopefully the same goes for some other users. Let me know if this is helpful or whether you'd rather I approach it another way.

Shift-enter conflicts with Hydrogen, a very popular Atom package. By making most of the keymaps (except for the toggle keymap) specific to when Hydra is enabled, they play nicely together.
