### PR TITLE
eval whole file

### DIFF
--- a/keymaps/atom-hydra.json
+++ b/keymaps/atom-hydra.json
@@ -3,6 +3,6 @@
     "ctrl-alt-o": "atom-hydra:toggle",
     "shift-enter": "atom-hydra:evalLine",
     "ctrl-enter": "atom-hydra:evalBlock",
-    "ctrl-alt-enter": "atom-hydra:evalBlock"
+    "ctrl-alt-enter": "atom-hydra:evalCode"
   }
 }

--- a/lib/atom-hydra.js
+++ b/lib/atom-hydra.js
@@ -17,7 +17,8 @@ export default {
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'atom-hydra:toggle': () => this.toggle(),
       'atom-hydra:evalLine': () => this.main.evalLine(),
-      'atom-hydra:evalBlock': () => this.main.evalBlock()
+      'atom-hydra:evalBlock': () => this.main.evalBlock(),
+      'atom-hydra:evalCode':() => this.main.evalCode()
     }));
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -69,7 +69,18 @@ export default class Main {
       var expression = editor.getTextInBufferRange(range);
       this._eval(expression)
     }
+  }
 
+  evalCode() {
+    let editor
+    if (editor = atom.workspace.getActiveTextEditor()) {
+      range = {
+        start: { row: 0, column: 0 },
+        end: { row: editor.getLastScreenRow() + 1, column: 0 }
+      }
+      this.evalFlash(range);
+      his._eval(editor.getText());
+    }
   }
 
   getCurrentParagraphIncludingComments(editor) {


### PR DESCRIPTION
Hey @ojack! Hydra is awesome!

So I was thinking it may be useful to write some sort of library for shorthand effects, i.e. instead of:
```js
if (tidal.s === "bd") {
     // do something
} else if (tidal.s === "sn") {
    // do something
}
```

something like:
```js
increaseRotationOn("bd");
invertOn("sn");
```

I digress...

In exploring this, I noticed that it was clunky to make updates to a filewhere you wanted to import something, the import wasn't *"remembered"*. Thus, it seemed useful to execute the whole file, which exists according to the main *hydra* repo. So, this PR adds that.

## TLDR

This PR adds the ability to execute an entire file in atom. I kept with `ctrl-alt-enter` since in atom, `ctrl-shift-enter` is new line.