### PR TITLE
Fix stream handling

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -204,7 +204,7 @@ export default class Main {
               }
             }).then((stream) => {
               const video = document.createElement('video')
-              video.src = window.URL.createObjectURL(stream)
+              video.srcObject = stream
               video.addEventListener('loadedmetadata', () => {
                 video.play().then(() => {
                   source.src = video


### PR DESCRIPTION
"Instead of setting the src property to URL.createObjectURL(stream) you're now supposed to set the srcObject property to the stream directly." - from https://stackoverflow.com/questions/53626318/chrome-update-failed-to-execute-createobjecturl-on-url/53734174

This fixed the initScreen failing for me (running latest atom on windows 10) for two different computers.