### PR TITLE
used desktopCapture.getSource as a promise

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -185,34 +185,38 @@ export default class Main {
 
     // hijack source init screen event because doesn't work in Electron
     this.hydra.s.forEach((source) => {
-      source.initScreen = (index) =>  desktopCapturer.getSources({types: ['window', 'screen']}, (error, sources) => {
-          if (error) throw error
-          this.log(sources)
-          if (sources.length > index) {
-            navigator.mediaDevices.getUserMedia({
-              audio: false,
-              video: {
-                mandatory: {
-                  chromeMediaSource: 'desktop',
-                  chromeMediaSourceId: sources[index].id,
-                //  minWidth: 1280,
-                  maxWidth: window.innerWidth,
-              //    minHeight: 720,
-                  maxHeight: window.innerHeight
+      source.initScreen = (index) =>  desktopCapturer.getSources({types: ['window', 'screen']}).then(async (sources) => {
+      this.log("initScreen sources : ", sources);
+        try {
+            if (sources.length > index) {
+              const stream = await navigator.mediaDevices.getUserMedia({
+                audio: false,
+                video: {
+                  mandatory: {
+                    chromeMediaSource: 'desktop',
+                    chromeMediaSourceId: sources[index].id,
+                  //  minWidth: 1280,
+                    maxWidth: window.innerWidth,
+                //    minHeight: 720,
+                    maxHeight: window.innerHeight
+                  }
                 }
-              }
-            }).then((stream) => {
+              })
               const video = document.createElement('video')
               video.srcObject = stream
               video.addEventListener('loadedmetadata', () => {
-                video.play().then(() => {
+              video.play().then(() => {
                   source.src = video
                   source.tex = source.regl.texture(source.src)
                 })
               })
-            })
-          }
-        })
+            }
+        } catch (error) {
+          console.log('initScreen error: ', error);
+          throw error
+        }
+    
+      })
     })
 
     const oscLoader = new OscLoader(PORT);

--- a/lib/main.js
+++ b/lib/main.js
@@ -186,7 +186,7 @@ export default class Main {
     // hijack source init screen event because doesn't work in Electron
     this.hydra.s.forEach((source) => {
       source.initScreen = (index) =>  desktopCapturer.getSources({types: ['window', 'screen']}).then(async (sources) => {
-      this.log("initScreen sources : ", sources);
+      this.log(sources);
         try {
             if (sources.length > index) {
               const stream = await navigator.mediaDevices.getUserMedia({


### PR DESCRIPTION
## Changes

- Changed electron's `desktopCapturer.getSources` function FROM recieving a callback function as input argument TO a executing that function in a promise . Realised this was what had to be done thanks to the issue [comment](https://github.com/ojack/atom-hydra/issues/40#issuecomment-855241567) by @fracnesco .

## Screenshots
![initScreen-log](https://user-images.githubusercontent.com/165956/134791933-ee095695-79e2-4af9-b334-df4b60a2dec9.png)


![inistScreen-test](https://user-images.githubusercontent.com/165956/134791899-f319a036-43bf-442e-9ede-947e259807b5.png)

## Checklist

- [ ] Requires dependency update?
- [x] ran the `testing/test.js` code
- [x] Looks good on large screens


fixes issue #40